### PR TITLE
Doesn't reconnect when pulsar server is restarted (WebSocket?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "restler": "~3.2",
-    "sockjs-client": "~1.0.0-beta.13",
+    "node-sockjs-client": "~1.0.7",
     "underscore": "~1.7",
     "async": "~0.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "restler": "~3.2",
-    "node-sockjs-client": "~1.0.7",
+    "sockjs-client": "~1.0.0-beta.13",
     "underscore": "~1.7",
     "async": "~0.9.0"
   },

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -1,4 +1,4 @@
-var SockJS = require('sockjs-client');
+var SockJS = require('node-sockjs-client');
 
 function Websocket(apiUrl, apiAuthToken) {
   this._jobList = {};
@@ -7,13 +7,13 @@ function Websocket(apiUrl, apiAuthToken) {
 
 Websocket.prototype.connect = function(url, authToken) {
   var sock = new SockJS(url);
-  if (authToken) {
-    sock.onopen = function() {
-      return sock.send(JSON.stringify({
+  sock.onopen = function() {
+    if (authToken) {
+      sock.send(JSON.stringify({
         token: authToken
       }));
-    };
-  }
+    }
+  };
 
   sock.onmessage = function(msg) {
     var data = JSON.parse(msg.data);
@@ -36,7 +36,7 @@ Websocket.prototype.connect = function(url, authToken) {
     }
   }.bind(this);
 
-  sock.onclose = function() {
+  sock.onclose = function(error) {
     this.connect(url, authToken);
   }.bind(this);
 };

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -35,6 +35,10 @@ Websocket.prototype.connect = function(url, authToken) {
       }
     }
   }.bind(this);
+
+  sock.onclose = function() {
+    this.connect(url, authToken);
+  }.bind(this);
 };
 
 Websocket.prototype._isJobEvent = function(event) {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -1,4 +1,4 @@
-var SockJS = require('node-sockjs-client');
+var SockJS = require('sockjs-client');
 
 function Websocket(apiUrl, apiAuthToken) {
   this._jobList = {};

--- a/test/client.js
+++ b/test/client.js
@@ -35,7 +35,7 @@ function testJobExecution(pulsarApi, job, done) {
 
 describe('tests of pulsar API', function() {
 
-  this.timeout(4000);
+  this.timeout(8000);
   var server;
 
   afterEach(function(done) {

--- a/test/client.js
+++ b/test/client.js
@@ -44,9 +44,6 @@ describe('tests of pulsar API', function() {
         done();
         server = null;
       });
-      _.each(server.openSockets, function(socket) {
-        socket.destroy();
-      });
     } else {
       done();
     }

--- a/test/client.js
+++ b/test/client.js
@@ -24,7 +24,7 @@ function testJobExecution(pulsarApi, job, done) {
   });
   job.on('change', changeSpy);
 
-  job.on('close', function() {
+  job.on('success', function() {
     changeSpy.should.have.been.called;
     job.data.status.should.equal(PulsarServerJob.STATUS.FINISHED);
     done();

--- a/test/config.js
+++ b/test/config.js
@@ -3,16 +3,16 @@ module.exports = {
     url: 'http://localhost:10031'
   },
   multiple: {
-    url: 'http://localhost:100032',
+    url: 'http://localhost:10032',
     auxiliary: {
       'alice/production': {
-        url: 'http://localhost:100033'
+        url: 'http://localhost:10033'
       },
       'alice/staging': {
-        url: 'http://localhost:100034'
+        url: 'http://localhost:10034'
       },
       'bob/': {
-        url: 'http://localhost:100034'
+        url: 'http://localhost:10034'
       }
     }
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,14 +10,7 @@ Helpers.getConfigPort = function(url) {
 };
 
 Helpers.createServer = function(config) {
-  var server = new ServerMock(Helpers.getConfigPort(config.url));
-  server.on('connection', function(socket) {
-    if (!server.openSockets) {
-      server.openSockets = [];
-    }
-    server.openSockets.push(socket);
-  });
-  return server;
+  return new ServerMock(Helpers.getConfigPort(config.url));
 };
 
 module.exports = Helpers;


### PR DESCRIPTION
Reproduce:
1. Start "pulsar-rest-api" server
2. Start "hubot-pulsar" using this client
3. Restart "pulsar-rest-api"
4. When running jobs, there will be no `success` and no `error` event

@vogdb @tomaszdurka I assume the client doesn't reconnect properly?