### PR TITLE
Add getter to retrieve job status

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "restler": "~3.2",
     "node-sockjs-client": "~1.0.7",
     "underscore": "~1.7",
+    "pulsar-rest-api": "~0.5.0",
     "async": "~0.9.0"
   },
   "devDependencies": {
@@ -30,7 +31,6 @@
     "express": "~4.9",
     "body-parser": "~1.8",
     "mocha": "~1.21",
-    "pulsar-rest-api": "~0.1",
     "sinon": "~1.10.3",
     "sinon-chai": "~2.6.0",
     "sockjs": "~0.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pulsar-rest-api-client-node",
   "description": "",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "./src/index",

--- a/src/job.js
+++ b/src/job.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
-var PulsarJob = require('../node_modules/pulsar-rest-api/lib/pulsar/job');
+var PulsarJob = require('pulsar-rest-api/lib/pulsar/job');
 
 /**
  * @param {String} app

--- a/src/job.js
+++ b/src/job.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
+var PulsarJob = require('../node_modules/pulsar-rest-api/lib/pulsar/job');
 
 /**
  * @param {String} app
@@ -27,6 +28,10 @@ util.inherits(Job, EventEmitter);
  */
 Job.prototype.setData = function(jobData) {
   return _.extend(this.data, jobData);
+};
+
+Job.prototype.isRunning = function() {
+  return this.data.status == PulsarJob.STATUS.RUNNING;
 };
 
 Job.prototype.toString = function() {

--- a/src/job.js
+++ b/src/job.js
@@ -30,6 +30,9 @@ Job.prototype.setData = function(jobData) {
   return _.extend(this.data, jobData);
 };
 
+/**
+ * @returns {boolean}
+ */
 Job.prototype.isRunning = function() {
   return this.data.status == PulsarJob.STATUS.RUNNING;
 };

--- a/test/client.js
+++ b/test/client.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var config = require('./config');
 var Helpers = require('./helpers');
 var PulsarApi = require('../src');
-var PulsarServerJob = require('../node_modules/pulsar-rest-api/lib/pulsar/job');
+var PulsarServerJob = require('pulsar-rest-api/lib/pulsar/job');
 
 var chai = require("chai");
 var sinon = require("sinon");

--- a/test/job.js
+++ b/test/job.js
@@ -1,0 +1,25 @@
+var assert = require("chai").assert;
+var Job = require('../src/job');
+var PulsarServerJob = require('pulsar-rest-api/lib/pulsar/job');
+
+describe('Job tests', function() {
+
+  var job;
+
+  beforeEach(function() {
+    job = new Job('app', 'env', 'task');
+  });
+
+  it('setData to .data', function() {
+    var data = {foo: 'bar'};
+    job.setData(data);
+    assert.deepEqual(job.data, data);
+  });
+
+  it('isRunning works', function() {
+    assert.isFalse(job.isRunning());
+    job.setData({status: PulsarServerJob.STATUS.RUNNING});
+    assert.isTrue(job.isRunning());
+  });
+
+});

--- a/test/job.js
+++ b/test/job.js
@@ -22,4 +22,14 @@ describe('Job tests', function() {
     assert.isTrue(job.isRunning());
   });
 
+  it('toString works', function() {
+    var data = {id: 'id'};
+    job.setData(data);
+    var serializedJob = job + '';
+    assert.include(serializedJob, job.app);
+    assert.include(serializedJob, job.env);
+    assert.include(serializedJob, job.task);
+    assert.include(serializedJob, data.id);
+  });
+
 });


### PR DESCRIPTION
It would be nice if the user of this API could retrieve a job's status, and determines if it's running or not *without* knowledge of the server code.
How about introducing something like `Job.isRunning()` (which could use the server's code)?

Reference: https://github.com/cargomedia/hubot-pulsar/blob/6a551d96c4dd49a8c16e930e106fc71ccb17b07b/src/job-monitor.js#L52